### PR TITLE
Use first language code if acceptFromHttp fails

### DIFF
--- a/src/Services/Languages.php
+++ b/src/Services/Languages.php
@@ -300,7 +300,7 @@ class Languages
     {
         if (!empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
             $locale = \Locale::acceptFromHttp($_SERVER['HTTP_ACCEPT_LANGUAGE']);
-            if ($locale == 'zh') {
+            if ($locale == 'zh' || $locale === false) {
                 $locales = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
                 $locale = array_shift($locales);
             }


### PR DESCRIPTION
This resolves an issue where the Norwegian language code 'no' returns
as 'false' from acceptFromHttp.